### PR TITLE
Compatible with Python 3

### DIFF
--- a/terminalplot/command.py
+++ b/terminalplot/command.py
@@ -31,10 +31,10 @@ from terminalplot import plot, get_terminal_size
 
 
 def list_floats(value):
-    values = value.split()
+    values = [float(v) for v in value.split()]
     if len(values) == 0:
         raise argparse.ArgumentError
-    return map(float, values)
+    return values
 
 parser = argparse.ArgumentParser(description='Minimalistic plot of a graph in terminal.',
                                  formatter_class=RawTextHelpFormatter,


### PR DESCRIPTION
The  `map` built-in in Python 3 returns a `<map object>`, and it crashes with a ValueError.

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "./terminalplot/terminalplot.py", line 21, in plot
    (max(y) - min(y)) if y and max(y) - min(y) != 0 else rows
ValueError: min() arg is an empty sequence
```
