### PR TITLE
Change tests from nose to pytest

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,2 @@
-[report]
-omit =
-    */python?.?/*
-    */site-packages/nose/*
+[run]
+omit = terminalplot/test/*

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 /build/
 /dist/
 /*.egg-info
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,10 +68,16 @@ install:
   - pip --version
   - pip install nose
   - nosetests --version
+  - pip install pytest
+  - pytest --version
+  - pip install coverage
+  - coverage --version
   - pip install coveralls
 
 script:
-  - nosetests --with-coverage --cover-package=terminalplot
+  - coverage run -m pytest
+  - coverage report -m
+  #- nosetests --with-coverage --cover-package=terminalplot
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ install:
   - pip install coveralls
 
 script:
-  - nosetests --with-coverage --cover-package=terminalplot
+  - nosetests --with-coverage --cover-package=terminalplot --exe
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,8 +75,9 @@ install:
   - pip install coveralls
 
 script:
-  - coverage run -m pytest
-  - coverage report -m
+  #- coverage run -m pytest
+  #- coverage report -m
+  - pytest --cov=terminalplot
   #- nosetests --with-coverage --cover-package=terminalplot
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,20 +66,13 @@ matrix:
 install:
   - python --version
   - pip --version
-  - pip install nose
-  - nosetests --version
   - pip install pytest
   - pip install pytest-cov
   - pytest --version
-  - pip install coverage
-  - coverage --version
   - pip install coveralls
 
 script:
-  #- coverage run -m pytest
-  #- coverage report -m
   - pytest --cov=terminalplot
-  #- nosetests --with-coverage --cover-package=terminalplot
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ install:
   - pip install coveralls
 
 script:
-  - nosetests --with-coverage --cover-package=terminalplot --exe
+  - nosetests --with-coverage --cover-package=terminalplot
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ install:
   - pip install nose
   - nosetests --version
   - pip install pytest
+  - pip install pytest-cov
   - pytest --version
   - pip install coverage
   - coverage --version

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,5 @@ setuptools.setup(
     zip_safe=True,
     entry_points={
         'console_scripts': ['plot = terminalplot.command:main']
-    },
-    test_suite='nose.collector',
-    tests_require=['nose']
+    }
 )


### PR DESCRIPTION
Nose has not run any tests in Windows on Travis, pytest works as expected. So nose is replaced with pytest. Additionally, `pytest-cov` is being added for test coverage.

Since `setup.py test` command is going to be deprecated (https://github.com/pypa/setuptools/issues/1684), `test_suite` is removed from `setup.py`. 